### PR TITLE
MaJ PHP 8+

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 # PHPEsker
-Library for PHP 7.2+ to interacts with [Esker](https://www.esker.com) Services.
+Library for PHP 8+ to interacts with [Esker](https://www.esker.com) Services.
 
 ## Installation
 ```bash

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,12 @@
       "email": "slye@nubox.fr",
       "homepage": "https://github.com/SBordier44",
       "role": "Developer"
+    },
+    {
+        "name": "Lucas D.",
+        "email": "ldesnoue@igmcentre.com",
+        "homepage": "https://github.com/LucasDesnoue",
+        "role": "Developer"
     }
   ],
   "support": {
@@ -25,7 +31,7 @@
   },
   "homepage": "https://github.com/NuBOXDevCom/PHPEsker",
   "require": {
-    "php": ">= 7.2"
+    "php": ">= 8"
   },
   "autoload": {
     "psr-4": {

--- a/src/Esker.php
+++ b/src/Esker.php
@@ -28,7 +28,13 @@ class Esker
     /**
      * @var bool
      */
-    private $debugMode;
+    private $traceMode;
+
+    /**
+     * @var bool
+     */
+    private $exceptionsMode;
+
     /**
      * @var QueryService
      */
@@ -50,9 +56,10 @@ class Esker
      * @throws BindingException
      * @throws LoginException
      */
-    public function __construct(string $username, string $password, bool $debugMode = false)
+    public function __construct(string $username, string $password, bool $traceMode = true, bool $exceptionsMode = false)
     {
-        $this->debugMode = $debugMode;
+        $this->traceMode = $traceMode;
+        $this->exceptionsMode = $exceptionsMode;
         $session = new SessionService('https://as1.ondemand.esker.com/EDPWS_D/EDPWS.dll?Handler=GenSession2WSDL');
         $bindings = $session->GetBindings($username);
         if ($session->eskerException) {
@@ -63,11 +70,11 @@ class Esker
         if ($session->eskerException) {
             throw new LoginException('Failed call Login : ' . $session->eskerException->Message);
         }
-        $this->submissionService = new SubmissionService($bindings->submissionServiceWSDL, $debugMode);
+        $this->submissionService = new SubmissionService($bindings->submissionServiceWSDL, $traceMode, $exceptionsMode);
         $this->submissionService->Url = $bindings->submissionServiceLocation;
         $this->submissionService->SessionHeaderValue = new SessionHeader();
         $this->submissionService->SessionHeaderValue->sessionID = $login->sessionID;
-        $this->queryService = new QueryService($bindings->queryServiceWSDL, $debugMode);
+        $this->queryService = new QueryService($bindings->queryServiceWSDL, $traceMode, $exceptionsMode);
         $this->queryService->Url = $bindings->queryServiceLocation;
         $this->queryService->SessionHeaderValue = new Query\SessionHeader();
         $this->queryService->SessionHeaderValue->sessionID = $login->sessionID;
@@ -218,9 +225,9 @@ class Esker
 
     /**
      * @param string $ruidex
-     * @return Query\Result
+     * @return ?Query\Result
      */
-    public function getLetterStatuses(string $ruidex): Query\Result
+    public function getLetterStatuses(string $ruidex): ?Query\Result
     {
         $this->queryService->QueryHeaderValue = new Header();
         $this->queryService->QueryHeaderValue->recipientType = 'MOD';

--- a/src/Query/QueryService.php
+++ b/src/Query/QueryService.php
@@ -36,9 +36,9 @@ class QueryService
      */
     public $QueryHeaderValue;
     /**
-     * @var EskerException
+     * @var ?EskerException
      */
-    public $eskerException;
+    public $eskerException = null;
     /**
      * @var string
      */
@@ -53,15 +53,14 @@ class QueryService
      * @param string $wsdl
      * @param bool $debugMode
      */
-    public function __construct(string $wsdl, bool $debugMode = false)
+    public function __construct(string $wsdl, bool $traceMode = true, bool $exceptionsMode = false)
     {
         $this->client = new SoapClient($wsdl, [
-                'trace' => $debugMode,
-                'exceptions' => $debugMode,
+                'trace' => $traceMode,
+                'exceptions' => $exceptionsMode,
                 'encoding' => 'utf-8'
             ]
         );
-        $this->eskerException = new EskerException();
     }
 
     /**
@@ -74,9 +73,9 @@ class QueryService
 
     /**
      * @param Request $request
-     * @return Result
+     * @return ?Result
      */
-    public function QueryFirst(Request $request): Result
+    public function QueryFirst(Request $request): ?Result
     {
         $this->_CheckEndPoint();
         $this->setQueryHeader();
@@ -86,6 +85,7 @@ class QueryService
             $queryResult = $this->getQueryResult($this->result->{'return'});
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
             return null;
         }
@@ -111,9 +111,9 @@ class QueryService
 
     /**
      * @param Request $request
-     * @return Result
+     * @return ?Result
      */
-    public function QueryNext(Request $request): Result
+    public function QueryNext(Request $request): ?Result
     {
         $this->_CheckEndPoint();
         $this->setQueryHeader();
@@ -123,6 +123,7 @@ class QueryService
             $queryResult = $this->getQueryResult($this->result->{'return'});
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
             return null;
         }
@@ -131,9 +132,9 @@ class QueryService
 
     /**
      * @param Request $request
-     * @return Result
+     * @return ?Result
      */
-    public function QueryLast(Request $request): Result
+    public function QueryLast(Request $request): ?Result
     {
         $this->_CheckEndPoint();
         $this->setQueryHeader();
@@ -143,6 +144,7 @@ class QueryService
             $queryResult = $this->getQueryResult($this->result->{'return'});
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
             return null;
         }
@@ -181,6 +183,7 @@ class QueryService
             $queryResult = $this->getQueryResult($this->result->{'return'});
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $queryResult;
@@ -203,6 +206,7 @@ class QueryService
             $attachments = $this->getAttachments($this->result->{'return'});
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $attachments;
@@ -228,6 +232,7 @@ class QueryService
             $statisticsResult->includeSubNodes = $wrapper->includeSubNodes;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $statisticsResult;
@@ -253,6 +258,7 @@ class QueryService
             $actionResult->errorReason = $wrapper->errorReason;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $actionResult;
@@ -278,6 +284,7 @@ class QueryService
             $actionResult->errorReason = $wrapper->errorReason;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $actionResult;
@@ -304,6 +311,7 @@ class QueryService
             $actionResult->errorReason = $wrapper->errorReason;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $actionResult;
@@ -330,6 +338,7 @@ class QueryService
             $actionResult->errorReason = $wrapper->errorReason;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $actionResult;
@@ -351,6 +360,7 @@ class QueryService
             $actionResult->errorReason = $wrapper->errorReason;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $actionResult;
@@ -372,6 +382,7 @@ class QueryService
             $actionResult->errorReason = $wrapper->errorReason;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $actionResult;
@@ -392,6 +403,7 @@ class QueryService
             $resultFile = $this->result->{'return'};
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $resultFile;
@@ -414,6 +426,7 @@ class QueryService
             $resultFile = $this->result->{'return'};
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $resultFile;

--- a/src/Session/SessionService.php
+++ b/src/Session/SessionService.php
@@ -24,9 +24,9 @@ class SessionService
      */
     public $result;
     /**
-     * @var EskerException
+     * @var ?EskerException
      */
-    public $eskerException;
+    public $eskerException = null;
     /**
      * @var string
      */
@@ -40,14 +40,13 @@ class SessionService
      * SessionService constructor.
      * @param string $wsdl
      */
-    public function __construct(string $wsdl)
+    public function __construct(string $wsdl, $exceptionsMode = false)
     {
         $this->client = new SoapClient($wsdl, [
                 'exceptions' => true,
                 'encoding' => 'utf-8'
             ]
         );
-        $this->eskerException = new EskerException();
     }
 
     /**
@@ -82,6 +81,7 @@ class SessionService
             $bindingResult->queryServiceWSDL = $wrapper->queryServiceWSDL;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = 'Unable to call Esker Bindings Service';
             trigger_error($this->eskerException->Message, E_USER_ERROR);
             exit(1);
@@ -108,6 +108,7 @@ class SessionService
             $this->SessionHeaderValue->sessionID = $loginResult->sessionID;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = 'Unable to call Esker Login Service';
             trigger_error($this->eskerException->Message, E_USER_ERROR);
             exit(1);
@@ -127,6 +128,7 @@ class SessionService
             $this->result = $this->client->__soapCall('Logout', ['parameters' => $param]);
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = 'Unable to call Esker Logout Service';
             trigger_error($this->eskerException->Message, E_USER_ERROR);
             exit(1);

--- a/src/Submission/SubmissionService.php
+++ b/src/Submission/SubmissionService.php
@@ -23,9 +23,9 @@ class SubmissionService
      */
     public $result;
     /**
-     * @var EskerException
+     * @var ?EskerException
      */
-    public $eskerException;
+    public $eskerException = null;
     /**
      * @var string
      */
@@ -40,15 +40,14 @@ class SubmissionService
      * @param string $wsdl
      * @param bool $debugMode
      */
-    public function __construct(string $wsdl, bool $debugMode = false)
+    public function __construct(string $wsdl, bool $traceMode = true, bool $debugMode = false)
     {
         $this->client = new SoapClient($wsdl, [
                 'exceptions' => $debugMode,
-                'trace' => $debugMode,
+                'trace' => $traceMode,
                 'encoding' => 'utf-8',
             ]
         );
-        $this->eskerException = new EskerException();
     }
 
     /**
@@ -78,6 +77,7 @@ class SubmissionService
             $submissionResult->transportID = $wrapper->transportID;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $submissionResult;
@@ -100,6 +100,7 @@ class SubmissionService
             $submissionResult->transportID = $wrapper->transportID;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $submissionResult;
@@ -122,6 +123,7 @@ class SubmissionService
             $submissionResult->transportID = $wrapper->transportID;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $submissionResult;
@@ -150,6 +152,7 @@ class SubmissionService
             $extractionResult->transports = $wrapper->transports;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $extractionResult;
@@ -178,6 +181,7 @@ class SubmissionService
             $extractionResult->transports = $wrapper->transports;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $extractionResult;
@@ -207,6 +211,7 @@ class SubmissionService
             $conversionResult->convertedFile->storageID = $wrapper->convertedFile->storageID;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $conversionResult;
@@ -227,6 +232,7 @@ class SubmissionService
             $resultFile = base64_decode($this->result->{'return'});
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $resultFile;
@@ -252,6 +258,7 @@ class SubmissionService
             $this->result = $this->client->__soapCall('RegisterResource', array('parameters' => $param));
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
     }
@@ -278,6 +285,7 @@ class SubmissionService
             }
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $resources;
@@ -297,6 +305,7 @@ class SubmissionService
             $this->result = $this->client->__soapCall('DeleteResource', ['parameters' => $param]);
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
     }
@@ -322,6 +331,7 @@ class SubmissionService
             $wsfile->storageID = $wrapper->storageID;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $wsfile;
@@ -348,6 +358,7 @@ class SubmissionService
             $wsfile->storageID = $wrapper->storageID;
             $this->eskerException = null;
         } catch (SoapFault $fault) {
+            $this->eskerException = new EskerException();
             $this->eskerException->Message = $fault->faultstring;
         }
         return $wsfile;


### PR DESCRIPTION
- MaJ PHP8

- Correction gestion EskerException 
`Si EskerException valait null et qu'il y avait un prochain appel de méthode et que celui tombe en erreur, alors exception sur l'accès à $this->eskerException->Message`

- Séparation debug mode en traceMode et exceptionsMode
`option "trace" de SOAP a true obligatoire pour l'utilisation des méthodes xxxxxNext / xxxxxPrevious`

